### PR TITLE
feat: command data model has been made to anemic.

### DIFF
--- a/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/CommandDataModelService.cs
+++ b/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/CommandDataModelService.cs
@@ -1,0 +1,136 @@
+﻿using EssentialFrame.Cqrs.Commands.Core.Interfaces;
+using EssentialFrame.Cqrs.Commands.Persistence.Const;
+using EssentialFrame.Cqrs.Commands.Persistence.Interfaces;
+using EssentialFrame.Cqrs.Commands.Persistence.Models;
+using EssentialFrame.Extensions;
+using EssentialFrame.Serialization.Interfaces;
+using EssentialFrame.Time;
+
+namespace EssentialFrame.Cqrs.Commands.Persistence;
+
+internal sealed class CommandDataModelService : ICommandDataModelService
+{
+    public CommandDataModel Create(ICommand command)
+    {
+        CommandDataModel commandDataModel = new CommandDataModel();
+
+        ValidateCommand(command);
+        ValidateCommandType(command.GetTypeFullName());
+        ValidateCommandType(command.GetClassName());
+
+        commandDataModel.CommandIdentifier = command.CommandIdentifier;
+        commandDataModel.CommandClass = command.GetClassName();
+        commandDataModel.CommandType = command.GetTypeFullName();
+        commandDataModel.Command = command;
+        commandDataModel.CreatedAt = SystemClock.UtcNow;
+
+        return commandDataModel;
+    }
+
+    public CommandDataModel Create(ICommand command, ISerializer serializer)
+    {
+        CommandDataModel commandDataModel = new CommandDataModel();
+
+        ValidateCommand(command);
+        ValidateCommandType(command.GetTypeFullName());
+        ValidateCommandType(command.GetClassName());
+
+        commandDataModel.CommandIdentifier = command.CommandIdentifier;
+        commandDataModel.CommandClass = command.GetClassName();
+        commandDataModel.CommandType = command.GetTypeFullName();
+        commandDataModel.Command = serializer.Serialize(command);
+        commandDataModel.CreatedAt = SystemClock.UtcNow;
+
+        return commandDataModel;
+    }
+
+    public void Start(CommandDataModel commandDataModel)
+    {
+        ValidateCommandSendStatuses(new[]
+        {
+            CommandSendingStatuses.Started, CommandExecutionStatuses.WaitingForExecution
+        });
+
+        commandDataModel.SendStarted = SystemClock.UtcNow;
+        commandDataModel.SendStatus = CommandSendingStatuses.Started;
+        commandDataModel.ExecutionStatus = CommandExecutionStatuses.WaitingForExecution;
+    }
+
+    public void Schedule(CommandDataModel commandDataModel, DateTimeOffset? at)
+    {
+        ValidateCommandSendStatuses(new[]
+        {
+            CommandSendingStatuses.Scheduled, CommandExecutionStatuses.WaitingForExecution
+        });
+
+        commandDataModel.SendScheduled = at;
+        commandDataModel.SendStatus = CommandSendingStatuses.Scheduled;
+        commandDataModel.ExecutionStatus = CommandExecutionStatuses.WaitingForExecution;
+    }
+
+    public void Cancel(CommandDataModel commandDataModel)
+    {
+        ValidateCommandSendStatuses(new[]
+        {
+            CommandSendingStatuses.Cancelled, CommandExecutionStatuses.ExecutionCancelled
+        });
+
+        commandDataModel.SendCancelled = SystemClock.UtcNow;
+        commandDataModel.SendStatus = CommandSendingStatuses.Cancelled;
+        commandDataModel.ExecutionStatus = CommandExecutionStatuses.ExecutionCancelled;
+    }
+
+    public void Complete(CommandDataModel commandDataModel, bool success)
+    {
+        ValidateCommandSendStatuses(new[]
+        {
+            CommandSendingStatuses.Completed, CommandExecutionStatuses.ExecutedSuccessfully,
+            CommandExecutionStatuses.ExecutedWithErrors
+        });
+
+        commandDataModel.SendCompleted = SystemClock.UtcNow;
+        commandDataModel.SendStatus = CommandSendingStatuses.Completed;
+
+        commandDataModel.ExecutionStatus = success
+            ? CommandExecutionStatuses.ExecutedSuccessfully
+            : CommandExecutionStatuses.ExecutedWithErrors;
+    }
+
+    private static void ValidateCommand(ICommand command)
+    {
+        if (command is null)
+        {
+            throw new ArgumentException("Command class cannot be null.");
+        }
+    }
+
+    private static void ValidateCommandType(string commandType)
+    {
+        if (commandType?.Length is <= 3 or >= 260)
+        {
+            throw new OverflowException(
+                $"Command type have to be longer or equal than 3 characters and shorter or equal than 100. Value: {commandType}");
+        }
+    }
+
+    private static void ValidateCommandClass(string commandClass)
+    {
+        if (commandClass?.Length is <= 3 or >= 260)
+        {
+            throw new OverflowException(
+                $"Command class have to be longer or equal than 3 characters and shorter or equal than 250. Value: {commandClass}");
+        }
+    }
+
+    private static void ValidateCommandSendStatuses(IEnumerable<string> commandStatuses)
+    {
+        foreach (string commandSendStatus in commandStatuses)
+        {
+            if (commandSendStatus?.Length is <= 3 or >= 30)
+            {
+                throw new OverflowException(
+                    $"Command status have to be longer or equal than 3 characters and shorter or equal than 30. Value: {commandSendStatus}");
+            }
+        }
+    }
+}

--- a/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/CommandDataModelService.cs
+++ b/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/CommandDataModelService.cs
@@ -12,7 +12,7 @@ internal sealed class CommandDataModelService : ICommandDataModelService
 {
     public CommandDataModel Create(ICommand command)
     {
-        CommandDataModel commandDataModel = new CommandDataModel();
+        CommandDataModel commandDataModel = new();
 
         ValidateCommand(command);
         ValidateCommandType(command.GetTypeFullName());
@@ -29,7 +29,7 @@ internal sealed class CommandDataModelService : ICommandDataModelService
 
     public CommandDataModel Create(ICommand command, ISerializer serializer)
     {
-        CommandDataModel commandDataModel = new CommandDataModel();
+        CommandDataModel commandDataModel = new();
 
         ValidateCommand(command);
         ValidateCommandType(command.GetTypeFullName());

--- a/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/Interfaces/ICommandDataModelService.cs
+++ b/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/Interfaces/ICommandDataModelService.cs
@@ -1,0 +1,20 @@
+﻿using EssentialFrame.Cqrs.Commands.Core.Interfaces;
+using EssentialFrame.Cqrs.Commands.Persistence.Models;
+using EssentialFrame.Serialization.Interfaces;
+
+namespace EssentialFrame.Cqrs.Commands.Persistence.Interfaces;
+
+public interface ICommandDataModelService
+{
+    CommandDataModel Create(ICommand command);
+
+    CommandDataModel Create(ICommand command, ISerializer serializer);
+
+    void Start(CommandDataModel commandDataModel);
+
+    void Schedule(CommandDataModel commandDataModel, DateTimeOffset? at);
+
+    void Cancel(CommandDataModel commandDataModel);
+
+    void Complete(CommandDataModel commandDataModel, bool success);
+}

--- a/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/Interfaces/ICommandMapper.cs
+++ b/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/Interfaces/ICommandMapper.cs
@@ -1,5 +1,6 @@
 ﻿using EssentialFrame.Cqrs.Commands.Core.Interfaces;
 using EssentialFrame.Cqrs.Commands.Persistence.Models;
+using EssentialFrame.Serialization.Interfaces;
 
 namespace EssentialFrame.Cqrs.Commands.Persistence.Interfaces;
 
@@ -7,9 +8,17 @@ public interface ICommandMapper
 {
     CommandDataModel Map(ICommand command);
 
+    CommandDataModel Map(ICommand command, ISerializer serializer);
+
     IReadOnlyCollection<CommandDataModel> Map(IEnumerable<ICommand> commands);
+
+    IReadOnlyCollection<CommandDataModel> Map(IEnumerable<ICommand> commands, ISerializer serializer);
 
     ICommand Map(CommandDataModel commandDataModel);
 
+    ICommand Map(CommandDataModel commandDataModel, ISerializer serializer);
+
     IReadOnlyCollection<ICommand> Map(IEnumerable<CommandDataModel> commandDataModels);
+
+    IReadOnlyCollection<ICommand> Map(IEnumerable<CommandDataModel> commandDataModels, ISerializer serializer);
 }

--- a/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/Interfaces/ICommandRepository.cs
+++ b/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/Interfaces/ICommandRepository.cs
@@ -1,4 +1,5 @@
 using EssentialFrame.Cqrs.Commands.Core.Interfaces;
+using EssentialFrame.Serialization.Interfaces;
 
 namespace EssentialFrame.Cqrs.Commands.Persistence.Interfaces;
 
@@ -7,6 +8,10 @@ public interface ICommandRepository
     void StartExecution(ICommand command);
 
     Task StartExecutionAsync(ICommand command, CancellationToken cancellationToken = default);
+
+    void StartExecution(ICommand command, ISerializer serializer);
+
+    Task StartExecutionAsync(ICommand command, ISerializer serializer, CancellationToken cancellationToken = default);
 
     void CancelExecution(Guid commandIdentifier);
 

--- a/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/Models/CommandDataModel.cs
+++ b/Src/Commands/EssentialFrame.Cqrs.Commands/Persistence/Models/CommandDataModel.cs
@@ -1,140 +1,26 @@
-using EssentialFrame.Cqrs.Commands.Core.Interfaces;
-using EssentialFrame.Cqrs.Commands.Persistence.Const;
-using EssentialFrame.Extensions;
-using EssentialFrame.Serialization.Interfaces;
-using EssentialFrame.Time;
-
 namespace EssentialFrame.Cqrs.Commands.Persistence.Models;
 
 public class CommandDataModel
 {
-    protected internal CommandDataModel(ICommand command)
-    {
-        CommandIdentifier = command.CommandIdentifier;
+    public virtual Guid CommandIdentifier { get; set; }
 
-        Validate(command, command.GetTypeFullName(), command.GetClassName());
+    public virtual object Command { get; set; }
 
-        CommandClass = command.GetClassName();
-        CommandType = command.GetTypeFullName();
-        Command = command;
-        CreatedAt = SystemClock.UtcNow;
-    }
+    public virtual string CommandClass { get; set; }
 
-    protected internal CommandDataModel(ICommand command, ISerializer serializer)
-    {
-        CommandIdentifier = command.CommandIdentifier;
+    public virtual string CommandType { get; set; }
 
-        Validate(command, command.GetTypeFullName(), command.GetClassName());
+    public virtual DateTimeOffset? SendScheduled { get; set; }
 
-        CommandClass = command.GetClassName();
-        CommandType = command.GetTypeFullName();
-        Command = serializer.Serialize(command);
-        CreatedAt = SystemClock.UtcNow;
-    }
+    public virtual DateTimeOffset? SendStarted { get; set; }
 
-    public virtual Guid CommandIdentifier { get; }
+    public virtual DateTimeOffset? SendCompleted { get; set; }
 
-    public virtual object Command { get; }
+    public virtual DateTimeOffset? SendCancelled { get; set; }
 
-    public virtual string CommandClass { get; }
+    public virtual DateTimeOffset? CreatedAt { get; set; }
 
-    public virtual string CommandType { get; }
+    public virtual string SendStatus { get; set; }
 
-    public virtual DateTimeOffset? SendScheduled { get; private set; }
-
-    public virtual DateTimeOffset? SendStarted { get; private set; }
-
-    public virtual DateTimeOffset? SendCompleted { get; private set; }
-
-    public virtual DateTimeOffset? SendCancelled { get; private set; }
-
-    public virtual DateTimeOffset? CreatedAt { get; }
-
-    public virtual string SendStatus { get; private set; }
-
-    public virtual string ExecutionStatus { get; private set; }
-
-    public virtual void Start()
-    {
-        ValidateCommandSendStatuses(new[]
-        {
-            CommandSendingStatuses.Started, CommandExecutionStatuses.WaitingForExecution
-        });
-
-        SendStarted = SystemClock.UtcNow;
-        SendStatus = CommandSendingStatuses.Started;
-        ExecutionStatus = CommandExecutionStatuses.WaitingForExecution;
-    }
-
-    public virtual void Schedule(DateTimeOffset? at)
-    {
-        ValidateCommandSendStatuses(new[]
-        {
-            CommandSendingStatuses.Scheduled, CommandExecutionStatuses.WaitingForExecution
-        });
-
-        SendScheduled = at;
-        SendStatus = CommandSendingStatuses.Scheduled;
-        ExecutionStatus = CommandExecutionStatuses.WaitingForExecution;
-    }
-
-    public virtual void Cancel()
-    {
-        ValidateCommandSendStatuses(new[]
-        {
-            CommandSendingStatuses.Cancelled, CommandExecutionStatuses.ExecutionCancelled
-        });
-
-        SendCancelled = SystemClock.UtcNow;
-        SendStatus = CommandSendingStatuses.Cancelled;
-        ExecutionStatus = CommandExecutionStatuses.ExecutionCancelled;
-    }
-
-    public virtual void Complete(bool success)
-    {
-        ValidateCommandSendStatuses(new[]
-        {
-            CommandSendingStatuses.Completed, CommandExecutionStatuses.ExecutedSuccessfully,
-            CommandExecutionStatuses.ExecutedWithErrors
-        });
-
-        SendCompleted = SystemClock.UtcNow;
-        SendStatus = CommandSendingStatuses.Completed;
-
-        ExecutionStatus = success
-            ? CommandExecutionStatuses.ExecutedSuccessfully
-            : CommandExecutionStatuses.ExecutedWithErrors;
-    }
-
-    private static void ValidateCommandSendStatuses(IEnumerable<string> commandStatuses)
-    {
-        foreach (string commandSendStatus in commandStatuses)
-        {
-            if (commandSendStatus?.Length is <= 3 or >= 30)
-            {
-                throw new OverflowException(
-                    $"Command status have to be longer or equal than 3 characters and shorter or equal than 30. Value: {commandSendStatus}");
-            }
-        }
-    }
-
-    private static void Validate(ICommand command, string commandType, string commandClass)
-    {
-        if (command is null)
-        {
-            throw new ArgumentException("Command class cannot be null.");
-        }
-
-        if (commandType?.Length is <= 3 or >= 100)
-        {
-            throw new OverflowException(
-                $"Command type have to be longer or equal than 3 characters and shorter or equal than 100. Value: {commandType}");
-        }
-
-        if (commandClass?.Length is <= 3 or >= 250)
-        {
-            throw new OverflowException(
-                $"Command class have to be longer or equal than 3 characters and shorter or equal than 250. Value: {commandClass}");
-        }
-    }
+    public virtual string ExecutionStatus { get; set; }
 }

--- a/Src/Commands/Tests/EssentialFrame.Cqrs.Commands.Tests.UnitTests/Persistence/CommandDataModelServiceTests.cs
+++ b/Src/Commands/Tests/EssentialFrame.Cqrs.Commands.Tests.UnitTests/Persistence/CommandDataModelServiceTests.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using Bogus;
+using EssentialFrame.Cqrs.Commands.Core.Interfaces;
+using EssentialFrame.Cqrs.Commands.Persistence;
+using EssentialFrame.Cqrs.Commands.Persistence.Const;
+using EssentialFrame.Cqrs.Commands.Persistence.Interfaces;
+using EssentialFrame.Cqrs.Commands.Persistence.Models;
+using EssentialFrame.ExampleApp.Commands.Posts;
+using EssentialFrame.ExampleApp.Identity;
+using EssentialFrame.Identity;
+using EssentialFrame.Serialization.Interfaces;
+using EssentialFrame.Tests.Utils;
+using EssentialFrame.Time;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace EssentialFrame.Cqrs.Commands.Tests.UnitTests.Persistence;
+
+[TestFixture]
+public class CommandDataModelServiceTests
+{
+    private readonly Faker _faker = new();
+    private readonly Mock<ISerializer> _serializerMock = new();
+    private readonly Mock<IIdentityService> _identityServiceMock = new();
+    private CommandDataModel _commandDataModel;
+
+    [SetUp]
+    public void Setup()
+    {
+        _commandDataModel = new CommandDataModel
+        {
+            CommandIdentifier = _faker.Random.Guid(),
+            CommandClass = typeof(ChangeTitleCommand).AssemblyQualifiedName,
+            CommandType = typeof(ChangeTitleCommand).FullName,
+            Command = _faker.Random.String(150, 300),
+            CreatedAt = SystemClock.UtcNow
+        };
+
+        _identityServiceMock.Setup(x => x.GetCurrent()).Returns(new IdentityContext());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _commandDataModel = null;
+        _serializerMock.Reset();
+        _identityServiceMock.Reset();
+    }
+
+    [Test]
+    public void Create_WhenCommandIsProvided_ShouldReturnCommandDataModel()
+    {
+        // Arrange
+        ChangeTitleCommand command = new(_identityServiceMock.Object.GetCurrent(), _faker.Random.String(10, 20),
+            _faker.Random.Bool());
+
+        ICommandDataModelService commandDataModelService = new CommandDataModelService();
+
+        // Act
+        CommandDataModel result = commandDataModelService.Create(command);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.CommandIdentifier.Should().NotBeEmpty();
+        result.CommandClass.Should().NotBeEmpty();
+        result.CommandType.Should().NotBeEmpty();
+        result.Command.Should().BeEquivalentTo(command);
+        result.CreatedAt.Should().BeCloseTo(SystemClock.UtcNow, TimeSpan.FromMilliseconds(Defaults.DefaultCloseTo));
+    }
+
+    [Test]
+    public void Create_WhenProvidedCommandIsNull_ShouldThrowArgumentException()
+    {
+        // Arrange
+        ICommandDataModelService commandDataModelService = new CommandDataModelService();
+
+        // Act
+        Action act = () => commandDataModelService.Create(null);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("Command class cannot be null.");
+    }
+
+    [Test]
+    public void Create_WhenCommandAndSerializerAreProvided_ShouldReturnCommandDataModel()
+    {
+        // Arrange
+        ChangeTitleCommand command = new(_identityServiceMock.Object.GetCurrent(), _faker.Random.String(10, 20),
+            _faker.Random.Bool());
+
+        string serializedCommand = _faker.Random.String(10, 35);
+        _serializerMock.Setup(x => x.Serialize(It.IsAny<ICommand>())).Returns(serializedCommand);
+
+        ICommandDataModelService commandDataModelService = new CommandDataModelService();
+
+        // Act
+        CommandDataModel result = commandDataModelService.Create(command, _serializerMock.Object);
+
+        // Assert
+        _serializerMock.Verify(x => x.Serialize(It.IsAny<ICommand>()), Times.Once);
+
+        result.Should().NotBeNull();
+        result.CommandIdentifier.Should().NotBeEmpty();
+        result.CommandClass.Should().NotBeEmpty();
+        result.CommandType.Should().NotBeEmpty();
+        result.Command.Should().Be(serializedCommand);
+        result.CreatedAt.Should().BeCloseTo(SystemClock.UtcNow, TimeSpan.FromMilliseconds(Defaults.DefaultCloseTo));
+    }
+
+    [Test]
+    public void Create_WhenSerializerIsProvidedButCommandIsNull_ShouldThrowArgumentException()
+    {
+        // Arrange
+        ICommandDataModelService commandDataModelService = new CommandDataModelService();
+
+        // Act
+        Action act = () => commandDataModelService.Create(null, _serializerMock.Object);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("Command class cannot be null.");
+    }
+
+    [Test]
+    public void Start_WhenCommandDataModelIsProvided_ShouldReturnCommandDataModel()
+    {
+        // Arrange
+        ICommandDataModelService commandDataModelService = new CommandDataModelService();
+
+        // Act
+        commandDataModelService.Start(_commandDataModel);
+
+        // Assert
+        _commandDataModel.SendStarted.Should()
+            .BeCloseTo(SystemClock.UtcNow, TimeSpan.FromMilliseconds(Defaults.DefaultCloseTo));
+        _commandDataModel.SendStatus.Should().Be(CommandSendingStatuses.Started);
+        _commandDataModel.ExecutionStatus.Should().Be(CommandExecutionStatuses.WaitingForExecution);
+    }
+
+    [Test]
+    public void Schedule_WhenCommandDataModelIsProvided_ShouldReturnCommandDataModel()
+    {
+        // Arrange
+        DateTimeOffset at = _faker.Date.FutureOffset();
+        ICommandDataModelService commandDataModelService = new CommandDataModelService();
+
+        // Act
+        commandDataModelService.Schedule(_commandDataModel, at);
+
+        // Assert
+        _commandDataModel.SendScheduled.Should().BeCloseTo(at, TimeSpan.FromMilliseconds(Defaults.DefaultCloseTo));
+        _commandDataModel.SendStatus.Should().Be(CommandSendingStatuses.Scheduled);
+        _commandDataModel.ExecutionStatus.Should().Be(CommandExecutionStatuses.WaitingForExecution);
+    }
+
+    [Test]
+    public void Cancel_WhenCommandDataModelIsProvided_ShouldReturnCommandDataModel()
+    {
+        // Arrange
+        ICommandDataModelService commandDataModelService = new CommandDataModelService();
+
+        // Act
+        commandDataModelService.Cancel(_commandDataModel);
+
+        // Assert
+        _commandDataModel.SendCancelled.Should()
+            .BeCloseTo(SystemClock.UtcNow, TimeSpan.FromMilliseconds(Defaults.DefaultCloseTo));
+        _commandDataModel.SendStatus.Should().Be(CommandSendingStatuses.Cancelled);
+        _commandDataModel.ExecutionStatus.Should().Be(CommandExecutionStatuses.ExecutionCancelled);
+    }
+
+    [Test]
+    public void Complete_WhenCommandDataModelIsProvidedAndExecutionSucceed_ShouldReturnCommandDataModel()
+    {
+        // Arrange
+        ICommandDataModelService commandDataModelService = new CommandDataModelService();
+
+        // Act
+        commandDataModelService.Complete(_commandDataModel, true);
+
+        // Assert
+        _commandDataModel.SendCompleted.Should()
+            .BeCloseTo(SystemClock.UtcNow, TimeSpan.FromMilliseconds(Defaults.DefaultCloseTo));
+        _commandDataModel.SendStatus.Should().Be(CommandSendingStatuses.Completed);
+        _commandDataModel.ExecutionStatus.Should().Be(CommandExecutionStatuses.ExecutedSuccessfully);
+    }
+
+    [Test]
+    public void Complete_WhenCommandDataModelIsProvidedAndExecutionFailed_ShouldReturnCommandDataModel()
+    {
+        // Arrange
+        ICommandDataModelService commandDataModelService = new CommandDataModelService();
+
+        // Act
+        commandDataModelService.Complete(_commandDataModel, false);
+
+        // Assert
+        _commandDataModel.SendCompleted.Should()
+            .BeCloseTo(SystemClock.UtcNow, TimeSpan.FromMilliseconds(Defaults.DefaultCloseTo));
+        _commandDataModel.SendStatus.Should().Be(CommandSendingStatuses.Completed);
+        _commandDataModel.ExecutionStatus.Should().Be(CommandExecutionStatuses.ExecutedWithErrors);
+    }
+}

--- a/Src/Commands/Tests/EssentialFrame.Cqrs.Commands.Tests.UnitTests/Persistence/CommandMapperTests.cs
+++ b/Src/Commands/Tests/EssentialFrame.Cqrs.Commands.Tests.UnitTests/Persistence/CommandMapperTests.cs
@@ -259,7 +259,7 @@ public class CommandMapperTests
 
     private CommandDataModel GenerateCommandDataModel(ICommand command, ISerializer serializer = null)
     {
-        CommandDataModel commandDataMode = new CommandDataModel
+        CommandDataModel commandDataModel = new()
         {
             CommandIdentifier = command.CommandIdentifier,
             CommandClass = command.GetClassName(),
@@ -268,7 +268,7 @@ public class CommandMapperTests
             CreatedAt = SystemClock.UtcNow
         };
 
-        return commandDataMode;
+        return commandDataModel;
     }
 
     private IReadOnlyCollection<ICommand> GenerateCommands()

--- a/Src/Commands/Tests/EssentialFrame.Cqrs.Commands.Tests.UnitTests/Store/CommandsRepositoryTests.cs
+++ b/Src/Commands/Tests/EssentialFrame.Cqrs.Commands.Tests.UnitTests/Store/CommandsRepositoryTests.cs
@@ -1,5 +1,0 @@
-﻿namespace EssentialFrame.Cqrs.Commands.Tests.UnitTests.Store;
-
-public class CommandsRepositoryTests
-{
-}


### PR DESCRIPTION
changes:
- removed logic from CommandDataModel.cs
- created service CommandDataModelService.cs to handle logic from CommandDataModel.cs
- wrote tests for these classes
- refactored mapper to be able to use serializer from parameter instead of constructor
- adjusted code to be able to use refactored classes