### PR TITLE
feat: refactor serializer and update tests.

### DIFF
--- a/Src/Core/EssentialFrame/Background/BackgroundService.cs
+++ b/Src/Core/EssentialFrame/Background/BackgroundService.cs
@@ -13,6 +13,7 @@ public abstract class BackgroundService : IHostedService, IBackgroundService, ID
 
     public virtual void Dispose()
     {
+        GC.SuppressFinalize(this);
         _stoppingCts.Cancel();
     }
 

--- a/Src/Core/EssentialFrame/Serialization/DefaultJsonSerializer.cs
+++ b/Src/Core/EssentialFrame/Serialization/DefaultJsonSerializer.cs
@@ -6,47 +6,32 @@ namespace EssentialFrame.Serialization;
 
 public class DefaultJsonSerializer : ISerializer
 {
-    public T Deserialize<T>(string value)
+    private readonly JsonSerializerOptions _serializerOptions;
+    
+    public DefaultJsonSerializer(JsonSerializerOptions serializerOptions = null)
     {
-        return JsonSerializer.Deserialize<T>(value);
+        _serializerOptions = serializerOptions;
     }
 
-    public T Deserialize<T>(string value, JsonSerializerOptions options)
+    public T Deserialize<T>(string value)
     {
-        return JsonSerializer.Deserialize<T>(value, options);
+        return JsonSerializer.Deserialize<T>(value, _serializerOptions);
     }
 
     public T Deserialize<T>(string value, Type type) where T : class
     {
-        object deserialized = JsonSerializer.Deserialize(value, type);
-
-        return deserialized as T;
-    }
-
-    public T Deserialize<T>(string value, Type type, JsonSerializerOptions options) where T : class
-    {
-        object deserialized = JsonSerializer.Deserialize(value, type, options);
+        object deserialized = JsonSerializer.Deserialize(value, type, _serializerOptions);
 
         return deserialized as T;
     }
 
     public object Deserialize(string value, Type type)
     {
-        return JsonSerializer.Deserialize(value, type);
-    }
-
-    public object Deserialize(string value, Type type, JsonSerializerOptions options)
-    {
-        return JsonSerializer.Deserialize(value, type, options);
+        return JsonSerializer.Deserialize(value, type, _serializerOptions);
     }
 
     public string Serialize<T>(T value)
     {
-        return JsonSerializer.Serialize(value);
-    }
-
-    public string Serialize<T>(T value, JsonSerializerOptions options)
-    {
-        return JsonSerializer.Serialize(value, options);
+        return JsonSerializer.Serialize(value, _serializerOptions);
     }
 }

--- a/Src/Core/EssentialFrame/Serialization/Interfaces/ISerializer.cs
+++ b/Src/Core/EssentialFrame/Serialization/Interfaces/ISerializer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.Json;
 
 namespace EssentialFrame.Serialization.Interfaces;
 
@@ -7,17 +6,9 @@ public interface ISerializer
 {
     T Deserialize<T>(string value);
 
-    T Deserialize<T>(string value, JsonSerializerOptions options);
-
     T Deserialize<T>(string value, Type type) where T : class;
-
-    T Deserialize<T>(string value, Type type, JsonSerializerOptions options) where T : class;
 
     object Deserialize(string value, Type type);
 
-    object Deserialize(string value, Type type, JsonSerializerOptions options);
-
     string Serialize<T>(T value);
-
-    string Serialize<T>(T value, JsonSerializerOptions options);
 }

--- a/Src/Core/Tests/EssentialFrame.Tests.UnitTests/Serialization/SerializerTests.cs
+++ b/Src/Core/Tests/EssentialFrame.Tests.UnitTests/Serialization/SerializerTests.cs
@@ -15,7 +15,12 @@ public class SerializerTests
 {
     private static readonly Faker Faker = new();
     private readonly ISerializer _serializer = new DefaultJsonSerializer();
-
+    
+    private readonly ISerializer _customSetupSerializer = new DefaultJsonSerializer(new JsonSerializerOptions
+    {
+        WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    });
+    
     private static readonly BasicSerializationTestObject BasicObject = new()
     {
         PrimaryId = Faker.Random.Guid(),
@@ -48,13 +53,8 @@ public class SerializerTests
     public void SerializeWithOptions_Always_ShouldSerializeObject(object serializedObject)
     {
         // Arrange
-        JsonSerializerOptions options = new()
-        {
-            WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
         // Act
-        string result = _serializer.Serialize(serializedObject, options);
+        string result = _customSetupSerializer.Serialize(serializedObject);
 
         // Assert
         result.Should().NotBeNullOrEmpty();
@@ -77,15 +77,11 @@ public class SerializerTests
     public void DeserializeBasicObjectWithOptions_Always_ShouldDeserializeObject()
     {
         // Arrange
-        JsonSerializerOptions options = new()
-        {
-            WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
-        string serializedObj = _serializer.Serialize(BasicObject, options);
+        // Act
+        string serializedObj = _customSetupSerializer.Serialize(BasicObject);
 
         // Act
-        SerializationTestObject result = _serializer.Deserialize<SerializationTestObject>(serializedObj, options);
+        SerializationTestObject result = _customSetupSerializer.Deserialize<SerializationTestObject>(serializedObj);
 
         // Assert
         result.Should().BeEquivalentTo(BasicObject);
@@ -109,17 +105,12 @@ public class SerializerTests
     public void DeserializeBasicObjectWithOptions_Always_ShouldDeserializeObjectWithCustomType()
     {
         // Arrange
-        JsonSerializerOptions options = new()
-        {
-            WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
-        string serializedObj = _serializer.Serialize(BasicObject);
+        // Act
+        string serializedObj = _customSetupSerializer.Serialize(BasicObject);
 
         // Act
         BasicSerializationTestObject result =
-            _serializer.Deserialize<BasicSerializationTestObject>(serializedObj, typeof(BasicSerializationTestObject),
-                options);
+            _customSetupSerializer.Deserialize<BasicSerializationTestObject>(serializedObj, typeof(BasicSerializationTestObject));
 
         // Assert
         result.Should().BeEquivalentTo(BasicObject);
@@ -143,15 +134,11 @@ public class SerializerTests
     public void DeserializeBasicObjectWithOptions_Always_ShouldDeserializeObjectWithUnspecifiedType()
     {
         // Arrange
-        JsonSerializerOptions options = new()
-        {
-            WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
-        string serializedObj = _serializer.Serialize(BasicObject);
+        // Act
+        string serializedObj = _customSetupSerializer.Serialize(BasicObject);
 
         // Act
-        object result = _serializer.Deserialize(serializedObj, typeof(SerializationTestObject), options);
+        object result = _customSetupSerializer.Deserialize(serializedObj, typeof(SerializationTestObject));
 
         // Assert
         result.Should().BeEquivalentTo(BasicObject);
@@ -174,15 +161,11 @@ public class SerializerTests
     public void DeserializeComplexObjectWithOptions_Always_ShouldDeserializeObject()
     {
         // Arrange
-        JsonSerializerOptions options = new()
-        {
-            WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
-        string serializedObj = _serializer.Serialize(ComplexObject, options);
+        // Act
+        string serializedObj = _customSetupSerializer.Serialize(ComplexObject);
 
         // Act
-        SerializationTestObject result = _serializer.Deserialize<SerializationTestObject>(serializedObj, options);
+        SerializationTestObject result = _customSetupSerializer.Deserialize<SerializationTestObject>(serializedObj);
 
         // Assert
         result.Should().BeEquivalentTo(ComplexObject);
@@ -207,16 +190,12 @@ public class SerializerTests
     public void DeserializeComplexObjectWithOptions_Always_ShouldDeserializeObjectWithCustomType()
     {
         // Arrange
-        JsonSerializerOptions options = new()
-        {
-            WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
+        // Act
         string serializedObj = _serializer.Serialize(ComplexObject);
 
         // Act
         SerializationTestObject result =
-            _serializer.Deserialize<SerializationTestObject>(serializedObj, typeof(SerializationTestObject), options);
+            _customSetupSerializer.Deserialize<SerializationTestObject>(serializedObj, typeof(SerializationTestObject));
 
         // Assert
         result.Should().BeEquivalentTo(ComplexObject);
@@ -239,15 +218,11 @@ public class SerializerTests
     public void DeserializeComplexObjectWithOptions_Always_ShouldDeserializeObjectWithUnspecifiedType()
     {
         // Arrange
-        JsonSerializerOptions options = new()
-        {
-            WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
-        string serializedObj = _serializer.Serialize(ComplexObject);
+        // Act
+        string serializedObj = _customSetupSerializer.Serialize(ComplexObject);
 
         // Act
-        object result = _serializer.Deserialize(serializedObj, typeof(SerializationTestObject), options);
+        object result = _customSetupSerializer.Deserialize(serializedObj, typeof(SerializationTestObject));
 
         // Assert
         result.Should().BeEquivalentTo(ComplexObject);

--- a/Src/Domain/Tests/EssentialFrame.Domain.Tests.UnitTests/Snapshots/SnapshotTests.cs
+++ b/Src/Domain/Tests/EssentialFrame.Domain.Tests.UnitTests/Snapshots/SnapshotTests.cs
@@ -41,7 +41,7 @@ public class SnapshotTests
         aggregate.ChangeDescription(expectedDescription);
         aggregate.ExtendExpirationDate(expectedExpiration);
 
-        ISetup<ISerializer, string> state = _serializerMock.Setup(s => s.Serialize(aggregate.State, null));
+        ISetup<ISerializer, string> state = _serializerMock.Setup(s => s.Serialize(aggregate.State));
 
         // Act
         PostSnapshot snapshot = new(aggregateIdentifier, aggregateVersion, state);


### PR DESCRIPTION
- the serializer, along with the serialization tests, have been refactored to implement a custom setup serializer in place of singular JsonSerializerOptions instances. This enables a cleaner, DRY way to utilize the serializer options. The purpose was to reduce redundancy and to streamline the handling of JsonSerializerOptions.
- backgroundService has been updated for garbage collection optimization.