### PR TITLE
feat: remove IIdentityService from AggregateRoot

### DIFF
--- a/Examples/EssentialFrame.ExampleApp/Domain/Posts/Aggregates/Post.cs
+++ b/Examples/EssentialFrame.ExampleApp/Domain/Posts/Aggregates/Post.cs
@@ -15,11 +15,6 @@ public sealed class Post : AggregateRoot
     {
     }
 
-    private Post(Guid aggregateIdentifier, int aggregateVersion, IIdentityService identityService) : base(
-        aggregateIdentifier, aggregateVersion, identityService)
-    {
-    }
-
     public override PostState CreateState()
     {
         return PostState.Create(AggregateIdentifier, GetType());
@@ -45,33 +40,33 @@ public sealed class Post : AggregateRoot
         }
     }
 
-    public void ChangeTitle(Title title)
+    public void ChangeTitle(Title title, IIdentityContext identityContext = null)
     {
-        ChangeTitleDomainEvent @event = new(AggregateIdentifier, GetIdentity(), title);
+        ChangeTitleDomainEvent @event = new(AggregateIdentifier, identityContext, title);
         Apply(@event);
     }
 
-    public void ChangeDescription(string description)
+    public void ChangeDescription(string description, IIdentityContext identityContext = null)
     {
-        ChangeDescriptionDomainEvent @event = new(AggregateIdentifier, GetIdentity(), description);
+        ChangeDescriptionDomainEvent @event = new(AggregateIdentifier, identityContext, description);
         Apply(@event);
     }
 
-    public void ExtendExpirationDate(DateTimeOffset newExpirationDate)
+    public void ExtendExpirationDate(DateTimeOffset newExpirationDate, IIdentityContext identityContext = null)
     {
-        ChangeExpirationDateDomainEvent @event = new(AggregateIdentifier, GetIdentity(), newExpirationDate);
+        ChangeExpirationDateDomainEvent @event = new(AggregateIdentifier, identityContext, newExpirationDate);
         Apply(@event);
     }
 
-    public void AddImages(HashSet<Image> images)
+    public void AddImages(HashSet<Image> images, IIdentityContext identityContext = null)
     {
-        AddImagesDomainEvent @event = new(AggregateIdentifier, GetIdentity(), images);
+        AddImagesDomainEvent @event = new(AggregateIdentifier, identityContext, images);
         Apply(@event);
     }
 
-    public void ChangeImageName(Guid imageId, string name)
+    public void ChangeImageName(Guid imageId, string name, IIdentityContext identityContext = null)
     {
-        ChangeImageNameDomainEvent @event = new(AggregateIdentifier, GetIdentity(), imageId, name);
+        ChangeImageNameDomainEvent @event = new(AggregateIdentifier, identityContext, imageId, name);
         Apply(@event);
     }
 }

--- a/Src/Domain/EssentialFrame.Domain/Aggregates/AggregateRoot.cs
+++ b/Src/Domain/EssentialFrame.Domain/Aggregates/AggregateRoot.cs
@@ -1,6 +1,5 @@
 ﻿using EssentialFrame.Domain.Events;
 using EssentialFrame.Domain.Exceptions;
-using EssentialFrame.Identity;
 using EssentialFrame.Serialization.Interfaces;
 
 namespace EssentialFrame.Domain.Aggregates;
@@ -8,7 +7,6 @@ namespace EssentialFrame.Domain.Aggregates;
 public abstract class AggregateRoot
 {
     private readonly List<IDomainEvent> _changes = new();
-    private readonly IIdentityService _identityService;
 
     protected AggregateRoot(Guid aggregateIdentifier, int aggregateVersion)
     {
@@ -16,19 +14,6 @@ public abstract class AggregateRoot
         {
             throw new MissingAggregateIdentifierException(GetType());
         }
-
-        AggregateIdentifier = aggregateIdentifier;
-        AggregateVersion = aggregateVersion;
-    }
-
-    protected AggregateRoot(Guid aggregateIdentifier, int aggregateVersion, IIdentityService identityService)
-    {
-        if (aggregateIdentifier == Guid.Empty)
-        {
-            throw new MissingAggregateIdentifierException(GetType());
-        }
-
-        _identityService = identityService ?? throw new ArgumentNullException(nameof(identityService));
 
         AggregateIdentifier = aggregateIdentifier;
         AggregateVersion = aggregateVersion;
@@ -46,16 +31,6 @@ public abstract class AggregateRoot
 
     public abstract AggregateState CreateState();
     public abstract void RestoreState(object aggregateState, ISerializer serializer = null);
-
-    public IIdentityContext GetIdentity()
-    {
-        if (_identityService is null)
-        {
-            throw new MissingIdentityContextException(GetType());
-        }
-
-        return _identityService.GetCurrent();
-    }
 
     public IDomainEvent[] GetUncommittedChanges()
     {

--- a/Src/Domain/EssentialFrame.Domain/Aggregates/AggregateState.cs
+++ b/Src/Domain/EssentialFrame.Domain/Aggregates/AggregateState.cs
@@ -21,14 +21,16 @@ public abstract class AggregateState
 
     protected virtual void CheckRule(AggregateBusinessRuleBase rule, bool useExtraParameters = true)
     {
-        if (rule.IsBroken())
+        if (!rule.IsBroken())
         {
-            if (useExtraParameters)
-            {
-                rule.AddExtraParameters();
-            }
-
-            throw new BusinessRuleValidationException(rule);
+            return;
         }
+
+        if (useExtraParameters)
+        {
+            rule.AddExtraParameters();
+        }
+
+        throw new BusinessRuleValidationException(rule);
     }
 }

--- a/Src/Domain/EssentialFrame.Domain/Entities/Entity.cs
+++ b/Src/Domain/EssentialFrame.Domain/Entities/Entity.cs
@@ -14,14 +14,16 @@ public abstract class Entity
 
     protected virtual void CheckRule(EntityBusinessRuleBase rule, bool useExtraParameters = true)
     {
-        if (rule.IsBroken())
+        if (!rule.IsBroken())
         {
-            if (useExtraParameters)
-            {
-                rule.AddExtraParameters();
-            }
-
-            throw new BusinessRuleValidationException(rule);
+            return;
         }
+
+        if (useExtraParameters)
+        {
+            rule.AddExtraParameters();
+        }
+
+        throw new BusinessRuleValidationException(rule);
     }
 }

--- a/Src/Domain/EssentialFrame.Domain/Events/DomainEventBase.cs
+++ b/Src/Domain/EssentialFrame.Domain/Events/DomainEventBase.cs
@@ -12,10 +12,10 @@ public abstract class DomainEventBase : IDomainEvent
 
     private DomainEventBase(IIdentityContext identityContext) : this()
     {
-        TenantIdentity = identityContext.Tenant.Identifier;
-        UserIdentity = identityContext.User.Identifier;
-        ServiceIdentity = identityContext.Service.GetFullIdentifier();
-        CorrelationIdentity = identityContext.Correlation.Identifier;
+        TenantIdentity = identityContext?.Tenant?.Identifier ?? Guid.Empty;
+        UserIdentity = identityContext?.User?.Identifier ?? Guid.Empty;
+        CorrelationIdentity = identityContext?.Correlation?.Identifier ?? Guid.Empty;
+        ServiceIdentity = identityContext?.Service?.GetFullIdentifier();
     }
 
     protected DomainEventBase(Guid aggregateIdentifier, IIdentityContext identityContext) : this(identityContext)
@@ -24,9 +24,8 @@ public abstract class DomainEventBase : IDomainEvent
     }
 
     protected DomainEventBase(Guid aggregateIdentifier, Guid eventIdentifier, IIdentityContext identityContext) : this(
-        identityContext)
+        aggregateIdentifier, identityContext)
     {
-        AggregateIdentifier = aggregateIdentifier;
         EventIdentifier = eventIdentifier;
     }
 

--- a/Src/Domain/EssentialFrame.Domain/Factories/GenericAggregateFactory.cs
+++ b/Src/Domain/EssentialFrame.Domain/Factories/GenericAggregateFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using EssentialFrame.Domain.Exceptions;
-using EssentialFrame.Identity;
 
 namespace EssentialFrame.Domain.Factories;
 
@@ -18,24 +17,6 @@ public static class GenericAggregateFactory<T>
                 parameterNames.Contains(nameof(aggregateVersion)))
             {
                 return (T)constructor.Invoke(new object[] { aggregateIdentifier, aggregateVersion });
-            }
-        }
-
-        throw new MissingConstructorException(typeof(T));
-    }
-
-    public static T CreateAggregate(Guid aggregateIdentifier, int aggregateVersion, IIdentityService identityService)
-    {
-        ConstructorInfo[] constructors = typeof(T).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
-
-        foreach (ConstructorInfo constructor in constructors)
-        {
-            List<string> parameterNames = constructor.GetParameters().Select(p => p.Name).ToList();
-
-            if (parameterNames.Contains(nameof(aggregateIdentifier)) &&
-                parameterNames.Contains(nameof(aggregateVersion)) && parameterNames.Contains(nameof(identityService)))
-            {
-                return (T)constructor.Invoke(new object[] { aggregateIdentifier, aggregateVersion, identityService });
             }
         }
 

--- a/Src/Domain/EssentialFrame.Domain/ValueObjects/ValueObject.cs
+++ b/Src/Domain/EssentialFrame.Domain/ValueObjects/ValueObject.cs
@@ -55,15 +55,17 @@ public abstract class ValueObject
 
     protected virtual void CheckRule(ValueObjectBusinessRuleBase rule, bool useExtraParameters = true)
     {
-        if (rule.IsBroken())
+        if (!rule.IsBroken())
         {
-            if (useExtraParameters)
-            {
-                rule.AddExtraParameters();
-            }
-
-            throw new BusinessRuleValidationException(rule);
+            return;
         }
+
+        if (useExtraParameters)
+        {
+            rule.AddExtraParameters();
+        }
+
+        throw new BusinessRuleValidationException(rule);
     }
 
     protected abstract IEnumerable<object> GetEqualityComponents();

--- a/Src/Domain/Tests/EssentialFrame.Domain.Tests.UnitTests/Events/DomainEventTests.cs
+++ b/Src/Domain/Tests/EssentialFrame.Domain.Tests.UnitTests/Events/DomainEventTests.cs
@@ -202,6 +202,7 @@ public sealed class DomainEventTests
         @event.AggregateVersion.Should().Be(0);
         @event.NewImages.Should().BeSameAs(images);
 
+
         // Act
         @event = new AddImagesDomainEvent(aggregateIdentifier, eventIdentifier, identityContext, images);
 

--- a/Src/Domain/Tests/EssentialFrame.Domain.Tests.UnitTests/Factories/GenericAggregateFactoryTests.cs
+++ b/Src/Domain/Tests/EssentialFrame.Domain.Tests.UnitTests/Factories/GenericAggregateFactoryTests.cs
@@ -2,7 +2,6 @@ using System;
 using Bogus;
 using EssentialFrame.Domain.Factories;
 using EssentialFrame.ExampleApp.Domain.Posts.Aggregates;
-using EssentialFrame.ExampleApp.Identity.Services;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -27,24 +26,5 @@ public sealed class GenericAggregateFactoryTests
         aggregate.Should().NotBeNull();
         aggregate.AggregateIdentifier.Should().Be(aggregateIdentifier);
         aggregate.AggregateVersion.Should().Be(aggregateVersion);
-    }
-
-    [Test]
-    public void CreateAggregateWithIdentity_Always_ShouldCreateInstanceAndAssignValues()
-    {
-        // Arrange
-        Guid aggregateIdentifier = _faker.Random.Guid();
-        int aggregateVersion = _faker.Random.Int();
-        IdentityService identityService = new();
-
-        // Act
-        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier, aggregateVersion,
-            identityService);
-
-        // Assert
-        aggregate.Should().NotBeNull();
-        aggregate.AggregateIdentifier.Should().Be(aggregateIdentifier);
-        aggregate.AggregateVersion.Should().Be(aggregateVersion);
-        aggregate.GetIdentity().Should().BeEquivalentTo(identityService.GetCurrent());
     }
 }

--- a/Src/Domain/Tests/EssentialFrame.Domain.Tests.UnitTests/Snapshots/SnapshotTests.cs
+++ b/Src/Domain/Tests/EssentialFrame.Domain.Tests.UnitTests/Snapshots/SnapshotTests.cs
@@ -30,16 +30,15 @@ public class SnapshotTests
 
         _identityServiceMock.Setup(ism => ism.GetCurrent()).Returns(new IdentityContext());
 
-        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier,
-            aggregateVersion, _identityServiceMock.Object);
-
+        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier, aggregateVersion);
         Title expectedTitle = Title.Create(_faker.Lorem.Sentence(), true);
         string expectedDescription = _faker.Lorem.Sentences();
         DateTimeOffset expectedExpiration = _faker.Date.FutureOffset();
+        IIdentityContext identityContext = _identityServiceMock.Object.GetCurrent();
 
-        aggregate.ChangeTitle(expectedTitle);
-        aggregate.ChangeDescription(expectedDescription);
-        aggregate.ExtendExpirationDate(expectedExpiration);
+        aggregate.ChangeTitle(expectedTitle, identityContext);
+        aggregate.ChangeDescription(expectedDescription, identityContext);
+        aggregate.ExtendExpirationDate(expectedExpiration, identityContext);
 
         ISetup<ISerializer, string> state = _serializerMock.Setup(s => s.Serialize(aggregate.State, null));
 

--- a/Src/DomainEvents/EssentialFrame.Domain.Events/Persistence/Aggregates/AggregateOfflineStorage.cs
+++ b/Src/DomainEvents/EssentialFrame.Domain.Events/Persistence/Aggregates/AggregateOfflineStorage.cs
@@ -16,13 +16,13 @@ internal sealed class AggregateOfflineStorage : IAggregateOfflineStorage
     private const string EventsFileName = "events.json";
     private const string MetadataFileName = "metadata.txt";
     private const string IndexFileName = "boxes.csv";
-    
+    private readonly IDomainEventMapper _domainEventMapper;
+
     private readonly IFileStorage _fileStorage;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<AggregateOfflineStorage> _logger;
-    private readonly IDomainEventMapper _domainEventMapper;
-    private readonly ISerializer _serializer;
     private readonly string _offlineStorageDirectory;
+    private readonly ISerializer _serializer;
 
     public AggregateOfflineStorage(IFileStorage fileStorage, IFileSystem fileSystem,
         ILogger<AggregateOfflineStorage> logger, IDomainEventMapper domainEventMapper, ISerializer serializer,
@@ -53,7 +53,7 @@ internal sealed class AggregateOfflineStorage : IAggregateOfflineStorage
             _fileStorage.Create(aggregateDirectory, MetadataFileName, metaDataContents);
 
             string indexFileContents =
-                $"{SystemClock.Now:yyyy/MM/dd-HH:mm},{aggregate},{aggregate.GetType().FullName},{eventsFileInfo.Length / 1024} KB,{aggregate.GetIdentity().Tenant.Name}\n";
+                $"{SystemClock.Now:yyyy/MM/dd-HH:mm},{aggregate},{aggregate.GetType().FullName},{eventsFileInfo.Length / 1024} KB.\n";
 
             _fileStorage.Create(aggregateDirectory, IndexFileName, indexFileContents);
         }
@@ -87,7 +87,7 @@ internal sealed class AggregateOfflineStorage : IAggregateOfflineStorage
                 cancellationToken: cancellationToken);
 
             string indexFileContents =
-                $"{SystemClock.Now:yyyy/MM/dd-HH:mm},{aggregate},{aggregate.GetType().FullName},{eventsFileInfo.Length / 1024} KB,{aggregate.GetIdentity().Tenant.Name}\n";
+                $"{SystemClock.Now:yyyy/MM/dd-HH:mm},{aggregate},{aggregate.GetType().FullName},{eventsFileInfo.Length / 1024} KB.\n";
 
             await _fileStorage.CreateAsync(aggregateDirectory, IndexFileName, indexFileContents,
                 cancellationToken: cancellationToken);

--- a/Src/DomainEvents/EssentialFrame.Domain.Events/Persistence/DomainEvents/DomainEventMapper.cs
+++ b/Src/DomainEvents/EssentialFrame.Domain.Events/Persistence/DomainEvents/DomainEventMapper.cs
@@ -5,7 +5,7 @@ using EssentialFrame.Serialization.Interfaces;
 
 namespace EssentialFrame.Domain.Events.Persistence.DomainEvents;
 
-public class DomainEventMapper : IDomainEventMapper
+internal sealed class DomainEventMapper : IDomainEventMapper
 {
     public DomainEventDataModel Map(IDomainEvent domainEvent)
     {

--- a/Src/DomainEvents/EssentialFrame.Domain.Events/Persistence/Snapshots/SnapshotMapper.cs
+++ b/Src/DomainEvents/EssentialFrame.Domain.Events/Persistence/Snapshots/SnapshotMapper.cs
@@ -3,7 +3,7 @@ using EssentialFrame.Domain.Snapshots;
 
 namespace EssentialFrame.Domain.Events.Persistence.Snapshots;
 
-public class SnapshotMapper : ISnapshotMapper
+internal sealed class SnapshotMapper : ISnapshotMapper
 {
     public SnapshotDataModel Map(Snapshot snapshot)
     {

--- a/Src/DomainEvents/Tests/EssentialFrame.Domain.Events.Tests.UnitTests/Events/AggregateOfflineStorageTests.cs
+++ b/Src/DomainEvents/Tests/EssentialFrame.Domain.Events.Tests.UnitTests/Events/AggregateOfflineStorageTests.cs
@@ -35,20 +35,21 @@ public class AggregateOfflineStorageTests
     [SetUp]
     public void SetUp()
     {
-        _identityServiceMock.Setup(ism => ism.GetCurrent()).Returns(new IdentityContext());
         _logger = NullLoggerFactory.Instance.CreateLogger<AggregateOfflineStorage>();
 
         Guid aggregateIdentifier = _faker.Random.Guid();
         const int aggregateVersion = 0;
+        Mock<IIdentityService> identityServiceMock = new Mock<IIdentityService>();
 
-        _aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier, aggregateVersion,
-            _identityServiceMock.Object);
+        identityServiceMock.Setup(identityService => identityService.GetCurrent()).Returns(new IdentityContext());
+
+        _aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier, aggregateVersion);
 
         _domainEvents = new List<IDomainEvent>
         {
-            new ChangeTitleDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
+            new ChangeTitleDomainEvent(aggregateIdentifier, identityServiceMock.Object.GetCurrent(),
                 Title.Create(_faker.Lorem.Sentence(), true)),
-            new ChangeDescriptionDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
+            new ChangeDescriptionDomainEvent(aggregateIdentifier, identityServiceMock.Object.GetCurrent(),
                 _faker.Lorem.Sentences())
         };
 
@@ -70,7 +71,6 @@ public class AggregateOfflineStorageTests
         _fileStorageMock.Reset();
         _serializerMock.Reset();
         _fileSystemMock.Reset();
-        _identityServiceMock.Reset();
         _domainEventMapperMock.Reset();
         _logger = null;
     }
@@ -79,7 +79,6 @@ public class AggregateOfflineStorageTests
     private readonly Mock<IFileStorage> _fileStorageMock = new();
     private readonly Mock<ISerializer> _serializerMock = new();
     private readonly Mock<IFileSystem> _fileSystemMock = new();
-    private readonly Mock<IIdentityService> _identityServiceMock = new();
     private readonly Mock<IDomainEventMapper> _domainEventMapperMock = new();
 
     private ILogger<AggregateOfflineStorage> _logger;

--- a/Src/DomainEvents/Tests/EssentialFrame.Domain.Events.Tests.UnitTests/Events/DefaultDomainEventStoreTests.cs
+++ b/Src/DomainEvents/Tests/EssentialFrame.Domain.Events.Tests.UnitTests/Events/DefaultDomainEventStoreTests.cs
@@ -266,8 +266,7 @@ public class DefaultDomainEventStoreTests
         // Arrange
         Guid aggregateIdentifier = _faker.Random.Guid();
         int aggregateVersion = _faker.Random.Int();
-        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier,
-            aggregateVersion, _identityServiceMock.Object);
+        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier, aggregateVersion);
         List<DomainEventDataModel> domainEventsDms = GenerateDomainEventsCollection(aggregateIdentifier);
         IEnumerable<KeyValuePair<Guid, DomainEventDataModel>> domainEventsDictionary =
             domainEventsDms?.Select(v => new KeyValuePair<Guid, DomainEventDataModel>(v.EventIdentifier, v));
@@ -293,8 +292,7 @@ public class DefaultDomainEventStoreTests
         // Arrange
         Guid aggregateIdentifier = Guid.NewGuid();
         int aggregateVersion = _faker.Random.Int();
-        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier,
-            aggregateVersion, _identityServiceMock.Object);
+        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier, aggregateVersion);
         List<DomainEventDataModel> domainEventsDms = GenerateDomainEventsCollection(aggregateIdentifier);
         IEnumerable<KeyValuePair<Guid, DomainEventDataModel>> domainEventsDictionary =
             domainEventsDms?.Select(v => new KeyValuePair<Guid, DomainEventDataModel>(v.EventIdentifier, v));
@@ -320,8 +318,7 @@ public class DefaultDomainEventStoreTests
         // Arrange
         Guid aggregateIdentifier = _faker.Random.Guid();
         int aggregateVersion = _faker.Random.Int();
-        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier,
-            aggregateVersion, _identityServiceMock.Object);
+        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier, aggregateVersion);
         List<DomainEventDataModel> domainEventsDms = GenerateDomainEventsCollection(aggregateIdentifier);
 
         _aggregateCacheMock.Setup(x => x.Get(aggregateIdentifier)).Returns(aggregate);
@@ -347,8 +344,7 @@ public class DefaultDomainEventStoreTests
         // Arrange
         Guid aggregateIdentifier = _faker.Random.Guid();
         int aggregateVersion = _faker.Random.Int();
-        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier,
-            aggregateVersion, _identityServiceMock.Object);
+        Post aggregate = GenericAggregateFactory<Post>.CreateAggregate(aggregateIdentifier, aggregateVersion);
         List<DomainEventDataModel> domainEventsDms = GenerateDomainEventsCollection(aggregateIdentifier);
 
         _aggregateCacheMock.Setup(x => x.Get(aggregateIdentifier)).Returns(aggregate);
@@ -372,12 +368,9 @@ public class DefaultDomainEventStoreTests
     {
         List<AggregateRoot> aggregates = new()
         {
-            GenericAggregateFactory<Post>.CreateAggregate(_faker.Random.Guid(), _faker.Random.Int(1, 1000),
-                _identityServiceMock.Object),
-            GenericAggregateFactory<Post>.CreateAggregate(_faker.Random.Guid(), _faker.Random.Int(1, 1000),
-                _identityServiceMock.Object),
-            GenericAggregateFactory<Post>.CreateAggregate(_faker.Random.Guid(), _faker.Random.Int(1, 1000),
-                _identityServiceMock.Object)
+            GenericAggregateFactory<Post>.CreateAggregate(_faker.Random.Guid(), _faker.Random.Int(1, 1000)),
+            GenericAggregateFactory<Post>.CreateAggregate(_faker.Random.Guid(), _faker.Random.Int(1, 1000)),
+            GenericAggregateFactory<Post>.CreateAggregate(_faker.Random.Guid(), _faker.Random.Int(1, 1000))
         };
 
         return aggregates;
@@ -385,35 +378,33 @@ public class DefaultDomainEventStoreTests
 
     private List<DomainEventDataModel> GenerateDomainEventsCollection(Guid aggregateIdentifier)
     {
+        IIdentityContext identityContext = _identityServiceMock.Object.GetCurrent();
+
         List<IDomainEvent> domainEvents = new()
         {
-            new ChangeDescriptionDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
-                _faker.Lorem.Sentences()),
-            new ChangeTitleDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
+            new ChangeDescriptionDomainEvent(aggregateIdentifier, identityContext, _faker.Lorem.Sentences()),
+            new ChangeTitleDomainEvent(aggregateIdentifier, identityContext,
                 Title.Create(_faker.Random.Word(), _faker.Random.Bool())),
-            new ChangeDescriptionDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
-                _faker.Lorem.Sentences()),
-            new ChangeTitleDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
+            new ChangeDescriptionDomainEvent(aggregateIdentifier, identityContext, _faker.Lorem.Sentences()),
+            new ChangeTitleDomainEvent(aggregateIdentifier, identityContext,
                 Title.Create(_faker.Random.Word(), _faker.Random.Bool())),
-            new ChangeTitleDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
+            new ChangeTitleDomainEvent(aggregateIdentifier, identityContext,
                 Title.Create(_faker.Random.Word(), _faker.Random.Bool())),
-            new AddImagesDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
+            new AddImagesDomainEvent(aggregateIdentifier, identityContext,
                 new HashSet<Image>
                 {
                     Image.Create(_faker.Random.Guid(), _faker.Random.Word(), _faker.Random.Bytes(389))
                 }),
-            new ChangeDescriptionDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
-                _faker.Lorem.Sentences()),
-            new AddImagesDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
+            new ChangeDescriptionDomainEvent(aggregateIdentifier, identityContext, _faker.Lorem.Sentences()),
+            new AddImagesDomainEvent(aggregateIdentifier, identityContext,
                 new HashSet<Image>
                 {
                     Image.Create(_faker.Random.Guid(), _faker.Random.Word(), _faker.Random.Bytes(2346)),
                     Image.Create(_faker.Random.Guid(), _faker.Random.Word(), _faker.Random.Bytes(982))
                 }),
-            new ChangeImageNameDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
-                _faker.Random.Guid(), _faker.Lorem.Word()),
-            new ChangeExpirationDateDomainEvent(aggregateIdentifier, _identityServiceMock.Object.GetCurrent(),
-                _faker.Date.Future())
+            new ChangeImageNameDomainEvent(aggregateIdentifier, identityContext, _faker.Random.Guid(),
+                _faker.Lorem.Word()),
+            new ChangeExpirationDateDomainEvent(aggregateIdentifier, identityContext, _faker.Date.Future())
         };
 
         List<DomainEventDataModel> domainEventDms = domainEvents.Select(e => new DomainEventDataModel


### PR DESCRIPTION
changes:
- remove identity service from the AggregateRoot.cs
- pass identity in examples via method parameter
- tests have been adjusted to cover this change